### PR TITLE
using 'tie', `$foo = "abc"` is available as synonym of `$foo->set("abc")`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ String::Incremental is ...
 
     sets to $val.
 
+    tying with String::Incremental, assignment syntax is available as synonym of this method:
+
+        tie my $str, 'String::Incremental', (
+            format => 'foo-%2=-%=',
+            orders => [ [0..2], 'abcd' ],
+        );
+
+        $str = 'foo-22-d';  # same as `$str->set( 'foo-22-d' )`
+        print "$str";  # -> 'foo-22-d';
+
 - increment() : Str
 
     increases positional state of order and returns its character.

--- a/lib/String/Incremental.pm
+++ b/lib/String/Incremental.pm
@@ -17,7 +17,7 @@ use overload (
     '='  => sub { $_[0] },
 );
 
-extends 'Exporter';
+extends qw( Exporter Tie::Scalar );
 
 our $VERSION = "0.01";
 
@@ -134,6 +134,20 @@ sub _extract_incremental_chars {
     }
 
     return wantarray ? @ch : \@ch;
+}
+
+sub TIESCALAR {
+    my ($class, @args) = @_;
+    return $class->new( @args );
+}
+
+sub FETCH { $_[0] }
+
+sub STORE {
+    my ($self, @args) = @_;
+    if ( ref( $args[0] ) eq '' ) {  # ignore when ++/--
+        $self->set( @args );
+    }
 }
 
 __PACKAGE__->meta->make_immutable();

--- a/lib/String/Incremental.pm
+++ b/lib/String/Incremental.pm
@@ -226,6 +226,16 @@ following two variables are equivalent:
 
 sets to $val.
 
+tying with String::Incremental, assignment syntax is available as synonym of this method:
+
+    tie my $str, 'String::Incremental', (
+        format => 'foo-%2=-%=',
+        orders => [ [0..2], 'abcd' ],
+    );
+
+    $str = 'foo-22-d';  # same as `$str->set( 'foo-22-d' )`
+    print "$str";  # -> 'foo-22-d';
+
 =item increment() : Str
 
 increases positional state of order and returns its character.

--- a/t/main/decrement.t
+++ b/t/main/decrement.t
@@ -84,4 +84,23 @@ subtest 'underflow' => sub {
     is "$str", 'aa', 'positional state should not be increased when die';
 };
 
+subtest 'tying' => sub {
+    tie my $str, 'String::Incremental', ( format => '%2=', orders => [ 'abc' ] );
+    ok tied $str, 'should be tied';
+
+    $str->items->[0]->__i( 2 );
+    $str->items->[1]->__i( 2 );
+    is "$str", 'cc';
+
+    lives_ok {
+        $str->decrement();
+        is "$str", 'cb';
+    };
+
+    lives_ok {
+        $str--;
+        is "$str", 'ca';
+    };
+};
+
 done_testing;

--- a/t/main/increment.t
+++ b/t/main/increment.t
@@ -79,4 +79,20 @@ subtest 'overflow' => sub {
     is "$str", 'cc', 'positional state should not be increased when die';
 };
 
+subtest 'tying' => sub {
+    tie my $str, 'String::Incremental', ( format => '%2=', orders => [ 'abc' ] );
+    ok tied $str, 'should be tied';
+    is "$str", 'aa';
+
+    lives_ok {
+        $str->increment();
+        is "$str", 'ab';
+    };
+
+    lives_ok {
+        $str++;
+        is "$str", 'ac';
+    };
+};
+
 done_testing;

--- a/t/main/set.t
+++ b/t/main/set.t
@@ -53,5 +53,33 @@ subtest 'ok' => sub {
     is "$str", 'foo-cx';
 };
 
-done_testing;
+subtest 'tying' => sub {
+    tie my $str, 'String::Incremental', ( format => '%s-%=%=', orders => [ 'foo', 'abc', 'xyz' ] );
+    ok tied $str, 'should be tied';
+    isa_ok $str, 'String::Incremental';
+    is "$str", 'foo-ax';
 
+    subtest 'ng' => sub {
+        dies_ok { $str = 'hoge' };
+        dies_ok { $str = 'foo-abc' };
+    };
+
+    subtest 'ok' => sub {
+        $str = 'foo-cz';
+        is "$str", 'foo-cz';
+        isa_ok $str, 'String::Incremental';
+        dies_ok {
+            $str++;
+        } 'cannot increment';
+
+        $str = 'foo-bz';
+        is "$str", 'foo-bz';
+        isa_ok $str, 'String::Incremental';
+        lives_ok {
+            $str++;
+            is "$str", 'foo-cx';
+        };
+    };
+};
+
+done_testing;

--- a/t/main/tie.t
+++ b/t/main/tie.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use String::Incremental;
+
+sub new {
+    my $str = String::Incremental->new( @_ );
+    return $str;
+}
+
+tie my $str, 'String::Incremental', ( format =>'%=%=', orders => [ 'abc', '123' ] );
+ok tied $str;
+isa_ok $str, 'String::Incremental';
+
+subtest 'properties' => sub {
+    is $str->format, '%s%s';
+    is scalar( @{$str->items} ), 2;
+    isa_ok $str->items->[0], 'String::Incremental::Char';
+    isa_ok $str->items->[1], 'String::Incremental::Char';
+    is scalar( @{$str->chars} ), 2;
+    for ( @{$str->chars} ) {
+        isa_ok $_, 'String::Incremental::Char';
+    }
+};
+
+done_testing;


### PR DESCRIPTION
ref: issue #2
